### PR TITLE
Provide greater support to older Android versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This tracking SDK works with the overall AWS SDK and the Amazon Location Authent
 Add the following lines to the dependencies section of your build.gradle file in Android Studio:
 
 ``` gradle
-implementation("software.amazon.location:tracking:0.0.1")
-implementation("software.amazon.location:auth:0.0.1")
+implementation("software.amazon.location:tracking:0.0.2")
+implementation("software.amazon.location:auth:0.0.2")
 implementation("com.amazonaws:aws-android-sdk-location:2.72.0")
 ```
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -11,7 +11,7 @@ mavenPublishing {
     publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
     signAllPublications()
 
-    coordinates("software.amazon.location", "tracking", "0.0.1")
+    coordinates("software.amazon.location", "tracking", "0.0.2")
 
     pom {
         name.set("My Library")
@@ -46,7 +46,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 21
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
@@ -88,7 +88,7 @@ dependencies {
     if (findProject(":authSdk") != null) {
         implementation(project(":authSdk"))
     } else {
-        implementation("software.amazon.location:auth:0.0.1")
+        implementation("software.amazon.location:auth:0.0.2")
     }
 
     val roomVersion = "2.6.1"

--- a/library/src/main/java/software/amazon/location/tracking/providers/BackgroundLocationService.kt
+++ b/library/src/main/java/software/amazon/location/tracking/providers/BackgroundLocationService.kt
@@ -178,7 +178,11 @@ class BackgroundLocationService : Service() {
     private fun stopService() {
         serviceCallback?.serviceStopped()
         locationTracker?.stopBackgroundLocationUpdates()
-        stopForeground(STOP_FOREGROUND_REMOVE)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+        } else {
+            stopForeground(true)
+        }
         stopSelf()
         isRunning = false
     }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Setting minimum Android API level to 21 (Android 5) to provide greater supported Android versions.
* stopForeground needs to be updated to handle an older version of Android not being able to call the new version of the method that was introduced in API level 24.
* **Important:** This PR should not be merged until https://github.com/aws-geospatial/amazon-location-mobile-auth-sdk-android/pull/7 has been published to Maven as it has a dependency on it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
