### PR TITLE
Add GitHub build and publish actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  # cancel jobs on PRs only
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checking out branch
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+      
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checking out branch
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Build with Gradle
+        run: ./gradlew build
+      
+      - name: Publish to Maven Central
+        env:
+          ORG_GRADLE_PROJECT_AuthSDKUsername: ${{ secrets.SONATYPE_ACCOUNT_USERNAME }}
+          ORG_GRADLE_PROJECT_AuthSDKPassword: ${{ secrets.SONATYPE_ACCOUNT_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SONATYPE_ACCOUNT_GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SONATYPE_ACCOUNT_GPG_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SONATYPE_ACCOUNT_GPG_KEY_PASSWORD }}
+        run: ./gradlew publishAllPublicationsToAuthSDKRepository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,9 @@ jobs:
       
       - name: Publish to Maven Central
         env:
-          ORG_GRADLE_PROJECT_AuthSDKUsername: ${{ secrets.SONATYPE_ACCOUNT_USERNAME }}
-          ORG_GRADLE_PROJECT_AuthSDKPassword: ${{ secrets.SONATYPE_ACCOUNT_PASSWORD }}
+          ORG_GRADLE_PROJECT_TrackingSDKUsername: ${{ secrets.SONATYPE_ACCOUNT_USERNAME }}
+          ORG_GRADLE_PROJECT_TrackingSDKPassword: ${{ secrets.SONATYPE_ACCOUNT_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SONATYPE_ACCOUNT_GPG_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SONATYPE_ACCOUNT_GPG_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SONATYPE_ACCOUNT_GPG_KEY_PASSWORD }}
-        run: ./gradlew publishAllPublicationsToAuthSDKRepository
+        run: ./gradlew publishAllPublicationsToTrackingSDKRepository

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Check the latest version of [auth SDK](https://mvnrepository.com/artifact/softwa
 Add the following lines to the dependencies section of your build.gradle file in Android Studio:
 
 ``` gradle
-implementation("software.amazon.location:tracking:0.0.2")
-implementation("software.amazon.location:auth:0.0.2")
+implementation("software.amazon.location:tracking:0.2.4")
+implementation("software.amazon.location:auth:0.2.4")
 implementation("aws.sdk.kotlin:location:1.2.21")
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,4 @@
 plugins {
   id("org.jetbrains.kotlin.android") version "1.9.0" apply false
   id("com.android.library") version "8.2.2" apply false
-  id("com.gradleup.nmcp") version "0.0.4"
-}
-
-nmcp {
-  publishAllProjectsProbablyBreakingProjectIsolation {
-    username = findProperty("mavenCentralUsername").toString()
-    password = findProperty("mavenCentralPassword").toString()
-    publicationType = "AUTOMATIC"
-  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,23 @@
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official
+# Enables namespacing of each library's R class so that its R class includes only the
+# resources declared in the library itself and none from the library's dependencies,
+# thereby reducing the size of the R class for that library
+android.nonTransitiveRClass=true

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -11,7 +11,7 @@ mavenPublishing {
     publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
     signAllPublications()
 
-    coordinates("software.amazon.location", "tracking", "0.0.2")
+    coordinates("software.amazon.location", "tracking", "0.2.4")
 
     pom {
         name.set("My Library")
@@ -87,7 +87,7 @@ dependencies {
     if (findProject(":authSdk") != null) {
         implementation(project(":authSdk"))
     } else {
-        implementation("software.amazon.location:auth:0.0.2")
+        implementation("software.amazon.location:auth:0.2.4")
     }
 
     val roomVersion = "2.6.1"

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -7,6 +7,16 @@ plugins {
     id("com.vanniktech.maven.publish") version "0.27.0"
 }
 
+publishing {
+    repositories {
+        maven {
+            name = "TrackingSDK"
+            url = uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/")
+            credentials(PasswordCredentials::class)
+        }
+    }
+}
+
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
     signAllPublications()
@@ -14,10 +24,10 @@ mavenPublishing {
     coordinates("software.amazon.location", "tracking", "0.2.4")
 
     pom {
-        name.set("My Library")
-        description.set("A description of what my library does.")
-        inceptionYear.set("2020")
-        url.set("https://github.com/username/mylibrary/")
+        name.set("Amazon Location Service Mobile Tracking SDK for Android")
+        description.set("These utilities help you when making Amazon Location Service API calls from your Android applications. This library uses the AWS SDK to call tracking APIs.")
+        inceptionYear.set("2024")
+        url.set("https://github.com/aws-geospatial/amazon-location-mobile-tracking-sdk-android")
         licenses {
             license {
                 name.set("The Apache License, Version 2.0")
@@ -27,15 +37,15 @@ mavenPublishing {
         }
         developers {
             developer {
-                id.set("username")
-                name.set("User Name")
-                url.set("https://github.com/username/")
+                id.set("aws-geospatial")
+                name.set("AWS Geospatial")
+                url.set("https://github.com/aws-geospatial")
             }
         }
         scm {
-            url.set("https://github.com/username/mylibrary/")
-            connection.set("scm:git:git://github.com/username/mylibrary.git")
-            developerConnection.set("scm:git:ssh://git@github.com/username/mylibrary.git")
+            url.set("https://github.com/aws-geospatial/amazon-location-mobile-tracking-sdk-android")
+            connection.set("scm:git:git://github.com/aws-geospatial/amazon-location-mobile-tracking-sdk-android")
+            developerConnection.set("scm:git:ssh://git@github.com/aws-geospatial/amazon-location-mobile-tracking-sdk-android")
         }
     }
 }

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest>
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 </manifest>


### PR DESCRIPTION
*Description of changes:* This change adds GitHub Actions CI/CD support. The build action will run on every pull request. The publish action will run on every release.

AWS has its own unique Maven Central endpoint and its own unique authentication process, so most of the public documentation will not work. We are using a plugin to help us adapt the workflow for this specific endpoint.

The publish action relies on repository-level secrets that can be configured by admins on the Settings tab.

The version number is set as 0.2.4 to match the authentication SDK version number. An upcoming documentation release includes this number, so we need to keep it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
