### PR TITLE
fix(github): reduced workflow permission scope

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
*Issue #, if available:*

Address code scan results

*Description of changes:*

Reduce github workflow permission to read contents and write for actions that publish.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
